### PR TITLE
Fix LDAP ACLs for ns7 NethServer/dev#5145

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
+++ b/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
@@ -89,6 +89,7 @@ foreach ( reverse
     qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
     qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
     qq(by dn.exact="cn=ldapservice,__OLCSUFFIX__" read),
+    qq(by users peername.ip="127.0.0.1" read),
     qq(by users ssf=71 read),
     qq(by anonymous read), # Enable SSSD enumerate
     qq(by * none),
@@ -100,7 +101,8 @@ foreach ( reverse
 foreach ( reverse
     qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
     qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
-    qq(by anonymous auth),
+    qq(by anonymous peername.ip="127.0.0.1" auth),
+    qq(by anonymous ssf=71 auth),
     qq(by self write),
     qq(by * none)
 ) {

--- a/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
+++ b/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
@@ -77,38 +77,36 @@ foreach(@entries) {
 }
 
 #
-# Create pam and libuser internal accounts (ACL permissions are
+# Create pam, libuser, ldapservice internal accounts (ACL permissions are
 # configured below).
 #
 $ldap->configServiceAccount('libuser') || $errors++;
 $ldap->configServiceAccount('pam') || $errors++;
+$ldap->configServiceAccount('ldapservice') || $errors++;
 
-#
-# Configure default ACLs:
-#
-$ldap->enforceAccessDirective(
-    join(' ',
-	 qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
-	 qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
-	 qq(by users ssf=71 read),
-         qq(by anonymous read), # Enable SSSD enumerate
-	 qq(by * none)),
-    '*'
-    ) || $errors++;
+# Configure default ACLs in a backward-compatible manner:
+foreach ( reverse
+    qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
+    qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
+    qq(by users ssf=71 read),
+    qq(by anonymous read), # Enable SSSD enumerate
+    qq(by * none),
+) {
+    $ldap->enforceAccessDirective($_, '*') || $errors++;
+}
 
-$ldap->enforceAccessDirective(
-    join(' ',    
-	 qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
-	 qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
-	 qq(by anonymous auth),
-	 qq(by self write),
-	 qq(by * none)), 
-    'userPassword'
-    ) || $errors++;
+# Access to userPassword attribute is subject to stronger restrictions:
+foreach ( reverse
+    qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
+    qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
+    qq(by anonymous auth),
+    qq(by self write),
+    qq(by * none)
+) {
+    $ldap->enforceAccessDirective($_, 'userPassword') || $errors++;
+}
 
-
-
-exit($errors);
+exit( ($errors > 0) ? 1 : 0 );
 
 
 

--- a/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
+++ b/root/etc/e-smith/events/actions/nethserver-directory-dit-setup
@@ -88,6 +88,7 @@ $ldap->configServiceAccount('ldapservice') || $errors++;
 foreach ( reverse
     qq(by dn.exact="cn=pam,$LdapInternalSuffix" peername.path="/var/run/ldapi" write),
     qq(by dn.exact="cn=libuser,$LdapInternalSuffix" peername.ip="127.0.0.1" write),
+    qq(by dn.exact="cn=ldapservice,__OLCSUFFIX__" read),
     qq(by users ssf=71 read),
     qq(by anonymous read), # Enable SSSD enumerate
     qq(by * none),

--- a/root/etc/e-smith/templates/etc/sudoers/20ldap
+++ b/root/etc/e-smith/templates/etc/sudoers/20ldap
@@ -2,7 +2,7 @@
     #
     # 20ldap
     #
-    push @cmnd_alias_httpd_admin, "/usr/bin/cat /var/lib/nethserver/secrets/libuser";
+    push @cmnd_alias_httpd_admin, "/usr/bin/cat /var/lib/nethserver/secrets/ldapservice";
     push @cmnd_alias_httpd_admin, "/usr/libexec/nethserver/ldap-list-users";
     push @cmnd_alias_httpd_admin, "/usr/libexec/nethserver/ldap-list-groups";
     '';

--- a/root/usr/share/nethesis/NethServer/Module/Sssd/Ldap.php
+++ b/root/usr/share/nethesis/NethServer/Module/Sssd/Ldap.php
@@ -34,10 +34,10 @@ class Ldap extends \Nethgui\Controller\AbstractController
     {
         parent::prepareView($view);
 
-        $pass = $this->getPlatform()->exec('sudo cat /var/lib/nethserver/secrets/libuser')->getOutput(); 
+        $pass = $this->getPlatform()->exec('sudo cat /var/lib/nethserver/secrets/ldapservice')->getOutput();
         $base = "dc=directory,dc=nh";
         $view['BaseDN'] = $base;
-        $view['BindDN'] = "cn=libuser,$base";
+        $view['BindDN'] = "cn=ldapservice,$base";
         $view['BindPassword'] = $pass;
         $view['UserDN'] = "ou=People,$base";
         $view['GroupDN'] = "ou=Groups,$base";


### PR DESCRIPTION
* Create builtin ``ldapservice`` account
* Do not require TLS from localhost

NethServer/dev#5145
