### PR TITLE
Fix installation procedure bug

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-conf
+++ b/root/etc/e-smith/events/actions/nethserver-directory-conf
@@ -28,7 +28,7 @@ use NethServer::Service;
 # Restore backup if present
 #
 if ( ! -f '/var/lib/ldap/cn.bdb' ) { # first configuration
-    if ( -f '/var/lib/nethserver/backup/ldap-config.ldif' ) { # backup is ready to be restored
+    if ( -s '/var/lib/nethserver/backup/ldap-config.ldif' ) { # backup is present and non-zero size
         system('/etc/e-smith/events/actions/nethserver-directory-restore-ldap');
     }
 }


### PR DESCRIPTION
If the backup config file exists, but it's empty the restore config
procedure has a side-effect: it wipes slapd.d/ contents.

This fix ensures the config backup is not empty, so that slapd.d/ is not wiped out.