### PR TITLE
Slapd: decrease log verbosity

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-conf
+++ b/root/etc/e-smith/events/actions/nethserver-directory-conf
@@ -108,6 +108,7 @@ my @configChangeList = (
 	 olcPasswordCryptSaltFormat => '$6$%.86s',
 	 olcTLSCACertificateFile => $CertificateFile,
 	 olcTLSCertificateFile => $CertificateFile,
+	 olcLogLevel => '0',
 	 olcTLSCertificateKeyFile => $CertificateFile,
 	 olcTLSVerifyClient => 'never',
 	 # dummy value, see delete below:


### PR DESCRIPTION
Log config changed to decrease slapd log verbosity.
Log verbosity removed completely setting LogLevel = 0.

NethServer/dev#5256