### PR TITLE
Display the help content for grou plugins

### DIFF
--- a/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Group.rst
+++ b/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_Group.rst
@@ -52,3 +52,6 @@ Delete
 
 This action removes the defined groups and their
 distribution lists. The shared mailboxes associated
+
+.. raw:: html
+   {{{INCLUDE NethServer_Module_Group_PlugService_*.html}}}


### PR DESCRIPTION
This commit permits to display the content help page of plugins