### PR TITLE
Fix OpenSSL/GnuTLS initialization issue

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-conf
+++ b/root/etc/e-smith/events/actions/nethserver-directory-conf
@@ -112,7 +112,7 @@ my @configChangeList = (
 	 olcTLSCertificateKeyFile => $CertificateFile,
 	 olcTLSVerifyClient => 'never',
 	 # dummy value, see delete below:
-	 olcTLSCACertificatePath => '/',
+	 olcTLSCACertificatePath => '/etc/openldap/certs',
     ]],
 
     # Refs #1491. Remove attribute, if set.  On CentOS-6.3 nss cert DB


### PR DESCRIPTION
Provide a path to a valid GnuTLS database to workaround start up
regression after 7.5.1804 upstream release.

NethServer/dev#5493