### PR TITLE
Fix restore for NS 7.5

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -176,6 +176,11 @@ event_actions('post-restore-config', qw(
     nethserver-directory-clean-accountsdb 65
 ));
 
+event_templates('post-restore-config', qw(
+    /etc/pki/tls/certs/slapd.pem
+));
+
+
 #
 # Event organization-save
 #


### PR DESCRIPTION
OpenLDAP doesn't stanrt if the certificate is not present

NethServer/dev#5512