### PR TITLE
Run yum from cache only during live upgrade

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
+++ b/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
@@ -44,7 +44,9 @@ if [[ -z $(/sbin/e-smith/config getprop nsdc IpAddress) ]]; then
     exit 1
 fi
 
-yum --skip-broken --downloadonly -y --disableplugin=nethserver_events install nethserver-dc
+if ! [[ -n "${NS6UPGRADE_DCRPM}" && -e "${NS6UPGRADE_DCRPM}" ]]; then
+    yum --skip-broken --downloadonly -y --disableplugin=nethserver_events install nethserver-dc
+fi
 
 # Drop this package
 yum -y --disableplugin=nethserver_events remove nethserver-directory
@@ -58,7 +60,11 @@ yum -y --disableplugin=nethserver_events remove nethserver-directory
 
 # Install nethserver-dc without running runlevel-adjust and firewall-adjust:
 # the slapd service must be running and its TCP port must be open
-yum -y --disableplugin=nethserver_events install nethserver-dc
+if [[ -n "${NS6UPGRADE_DCRPM}" && -e "${NS6UPGRADE_DCRPM}" ]]; then
+    yum -C -y --disableplugin=nethserver_events install ${NS6UPGRADE_DCRPM}
+else
+    yum -y --disableplugin=nethserver_events install nethserver-dc
+fi
 
 /sbin/e-smith/signal-event nethserver-dc-update
 

--- a/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
+++ b/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
@@ -44,7 +44,7 @@ if [[ -z $(/sbin/e-smith/config getprop nsdc IpAddress) ]]; then
     exit 1
 fi
 
-if ! [[ -n "${NS6UPGRADE_DCRPM}" && -e "${NS6UPGRADE_DCRPM}" ]]; then
+if [[ ! -e "${NS6UPGRADE_DCRPM}" ]]; then
     yum --skip-broken --downloadonly -y --disableplugin=nethserver_events install nethserver-dc
 fi
 
@@ -60,7 +60,7 @@ yum -y --disableplugin=nethserver_events remove nethserver-directory
 
 # Install nethserver-dc without running runlevel-adjust and firewall-adjust:
 # the slapd service must be running and its TCP port must be open
-if [[ -n "${NS6UPGRADE_DCRPM}" && -e "${NS6UPGRADE_DCRPM}" ]]; then
+if [[ -e "${NS6UPGRADE_DCRPM}" ]]; then
     yum -C -y --disableplugin=nethserver_events install ${NS6UPGRADE_DCRPM}
 else
     yum -y --disableplugin=nethserver_events install nethserver-dc


### PR DESCRIPTION
If the `NS6UPGRADE_DCRPM` environment variable is set, the action uses a local RPM file instead of downloading it from the remote RPM repository.

This condition is set by the live upgrade procedure during the post-upgrade step. Here's where the variable value is assigned and marked to be exported to the environment:

https://github.com/NethServer/nethserver-upgrade-tool/blob/master/root/root/preupgrade/postupgrade.d/nethserver-system-upgrade/S55account-provider-upgrade#L38

NethServer/dev#5564