### PR TITLE
Fix missing UPN attributes

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
+++ b/root/etc/e-smith/events/actions/nethserver-directory-ns6upgrade
@@ -154,6 +154,9 @@ if [ -f /var/run/lost_users ]; then
     done
 fi
 
+# Fix the userPrincipalName attribute of existing users
+/etc/e-smith/events/actions/nethserver-dc-sync-upn || :
+
 # Lock the administrator account
 /etc/e-smith/events/actions/nethserver-dc-user-lock ${1:-ns6upgrade} "administrator@$(hostname -d)"
 


### PR DESCRIPTION
The sync-upn action is invoked only during user-create. As we start with
a pre-filled LDAP tree, we must fix existing entries for consistency.

NethServer/dev#6020