### PR TITLE
unlock: prevent unlock of users without password

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-user-unlock
+++ b/root/etc/e-smith/events/actions/nethserver-directory-user-unlock
@@ -37,9 +37,11 @@ if( ! $userName ) {
 $userName = (split(/@/,$userName))[0];
 
 # Do not unlock users without password
-my $currentPassword = `/usr/bin/ldapsearch -o ldif-wrap=no -LLL -Y EXTERNAL '(uid=$userName)' userPassword 2>/dev/null | /usr/bin/grep userPassword | /usr/bin/cut -d':' -f 3 | /usr/bin/base64 -id`;
+my $currentPassword = qx(/usr/bin/ldapsearch -o ldif-wrap=no -LLL -Y EXTERNAL '(uid=$userName)' userPassword 2>/dev/null | /usr/bin/grep ^userPassword);
 chomp $currentPassword;
-if ($currentPassword eq '{CRYPT}!!') {
+
+# e0NSWVBUfSEh is base64 form of empty password: {CRYPT}!!
+if ($currentPassword eq 'userPassword:: e0NSWVBUfSEh') {
     print("[NOTICE] Skipping unlock for user $userName\n");
     exit(0);
 }
@@ -48,4 +50,3 @@ system("/usr/sbin/lusermod", "-U", $userName) == 0
         or die "[ERROR] could not unlock account $userName\n";
 
 exit 0;
-

--- a/root/etc/e-smith/events/actions/nethserver-directory-user-unlock
+++ b/root/etc/e-smith/events/actions/nethserver-directory-user-unlock
@@ -36,6 +36,14 @@ if( ! $userName ) {
 
 $userName = (split(/@/,$userName))[0];
 
+# Do not unlock users without password
+my $currentPassword = `/usr/bin/ldapsearch -o ldif-wrap=no -LLL -Y EXTERNAL '(uid=$userName)' userPassword 2>/dev/null | /usr/bin/grep userPassword | /usr/bin/cut -d':' -f 3 | /usr/bin/base64 -id`;
+chomp $currentPassword;
+if ($currentPassword eq '{CRYPT}!!') {
+    print("[NOTICE] Skipping unlock for user $userName\n");
+    exit(0);
+}
+
 system("/usr/sbin/lusermod", "-U", $userName) == 0
         or die "[ERROR] could not unlock account $userName\n";
 


### PR DESCRIPTION
If a user without password was unlocked, future password would be
be encrypted using DES, limiting the length of the password to 8 chars.

NethServer/dev#6194