### PR TITLE
Fix users list calculation

### DIFF
--- a/nethserver-directory.spec
+++ b/nethserver-directory.spec
@@ -10,6 +10,7 @@ URL: %{url_prefix}/%{name}
 Requires: openldap-clients, openldap-servers
 Requires: perl-LDAP
 Requires: nethserver-sssd
+Requires: jq
 
 BuildRequires: nethserver-devtools
 

--- a/root/etc/e-smith/events/actions/nethserver-directory-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-password-policy
@@ -43,7 +43,7 @@ my $errors = 0;
 if($userName) {
     @users = ($userName);
 } else {
-    @users = split(/,/, qx(/usr/libexec/nethserver/list-users | jq -j '.|keys|join(",")'));
+    @users = split(/,/, qx(/usr/libexec/nethserver/list-users | /usr/bin/jq -j '.|keys|join(",")'));
 }
 
 my %conf = ();

--- a/root/etc/e-smith/events/actions/nethserver-directory-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-password-policy
@@ -43,14 +43,7 @@ my $errors = 0;
 if($userName) {
     @users = ($userName);
 } else {
-    tie my %udb, 'NethServer::Database::Passwd';
-
-    foreach my $user (keys %udb) {
-        my $uid  = db_get_prop(\%udb, $user, 'uid') || next;
-        if ($uid >= 1000) {
-            push(@users, $user);
-        }
-     }
+    @users = split(/,/, qx(/usr/libexec/nethserver/list-users | jq -j '.|keys|join(",")'));
 }
 
 my %conf = ();


### PR DESCRIPTION
The `NethServer::Database::Passwd backend` does not return the user listing since sssd users enumeration was turned off in nethserver-sssd 1.7.0.

User list is now properly filtered and returned by the list-users helper script.

Finally I preferred to use `jq` instead of the Perl JSON library to avoid any possible Perl UTF-8 encoding issues of the `gecos` field.

NethServer/dev#6387