### PR TITLE
Override sssd.conf to alter the password policy

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -64,6 +64,9 @@ event_actions($_, qw(
 ));
 
 # Update user settings when password policy changes:
+event_templates('password-policy-update', qw(
+    /etc/sssd/sssd.conf
+));
 event_actions('password-policy-update',
 	      'nethserver-directory-password-policy' => '30');
 

--- a/createlinks
+++ b/createlinks
@@ -48,7 +48,6 @@ event_actions('nethserver-directory-update', qw(
               nethserver-directory-fixconfig             12
               nethserver-directory-tlspolicy             20
 	      nethserver-directory-createadmins          50
-	      nethserver-directory-password-policy       60
 	      nethserver-directory-sssd                  90
 ));
 

--- a/root/etc/e-smith/events/actions/nethserver-directory-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-password-policy
@@ -30,67 +30,52 @@
 
 use strict;
 use esmith::ConfigDB;
-use esmith::db;
-use NethServer::Database::Passwd;
+use NethServer::Service;
 
 my $event = shift || die "Event name argument missing.";
 my $userName = shift;
 my $PassExpires = shift || "yes";
-my @users;
+my %users;
 
 my $errors = 0;
 
-if($userName) {
-    @users = ($userName);
+my %conf = esmith::ConfigDB->open_ro()->as_hash;
+
+if($conf{'passwordstrength'}{'PassExpires'} eq 'no') {
+    # Global policy is non-expiring passwords: do not touch users
+    %users = ();
+} elsif($userName) {
+    # Act on just one user record
+    $userName =~ s/\@.+//;
+    %users = ($userName => $PassExpires);
 } else {
-    @users = split(/,/, qx(/usr/libexec/nethserver/list-users | /usr/bin/jq -j '.|keys|join(",")'));
+    # Change aging attributes where they are already set
+    %users = split(/,/, qx(/usr/libexec/nethserver/list-users -s | jq -j 'to_entries | map(.key + "," + .value.expires) | join(",")'));
 }
 
-my %conf = ();
-my $db = esmith::ConfigDB->open_ro();
-
-my $policy = $db->get('passwordstrength');
-if($policy) {
-    %conf = $policy->props();
-} else {
-    die "[ERROR] No passwordstrength configuration found!\n";
-}
-
-foreach $userName (@users) {
-
-    my $ldapAccount = $userName;
-    if ($userName =~ /@/) {
-        $ldapAccount = (split(/@/,$userName))[0];
-    } else {
-        my $domain = $db->get_value('DomainName');
-        $userName = $userName.'@'.$domain
-    }
-
-    if( ! getpwnam($userName)) {
-	# Skip if user is not in system passwd DB
-	next;
-    }
-
-    if($conf{'PassExpires'} ne 'no' && ($PassExpires ne 'no')) {
+foreach my $ldapAccount (keys %users) {
+    if($users{$ldapAccount} ne 'no') {
         system("/usr/sbin/lchage",
             "-m", $conf{"MinPassAge"} || '0',
             "-M", $conf{"MaxPassAge"} || '180',
             "-W", $conf{"PassWarning"} || '7',
             $ldapAccount);
-	if( $? != 0 ) {
-	    warn "[ERROR] Cannot set password age infos for user `$userName`\n";
-	    $errors ++;	    
-	}
+        if( $? != 0 ) {
+            warn "[ERROR] Cannot set password age infos for user `$ldapAccount`\n";
+	        $errors++;
+	    }
     } else {
         system(qw(/usr/sbin/lchage -m 0 -M 99999 -W 7), $ldapAccount);
-	if( $? != 0 ) {
-	    warn "[ERROR] Cannot remove password age infos for user `$userName`\n";
-	    $errors ++;	    
-	}
+        if( $? != 0 ) {
+	        warn "[ERROR] Cannot remove password age infos for user `$ldapAccount`\n";
+	        $errors++;
+        }
     }
+}
 
+if(!$userName) {
+    # Restart SSSD to pick up sssd.conf changes
+    NethServer::Service->new('sssd')->restart() || ++$errors;
 }
 
 exit(($errors > 0) ? 1 : 0);
-
-

--- a/root/etc/e-smith/events/actions/nethserver-directory-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-password-policy
@@ -39,9 +39,9 @@ my %users;
 
 my $errors = 0;
 
-my %conf = esmith::ConfigDB->open_ro()->as_hash;
+my %conf = (esmith::ConfigDB->open_ro()->get('passwordstrength')->props()) or die("Could not read passwordstrength key");
 
-if($conf{'passwordstrength'}{'PassExpires'} eq 'no') {
+if($conf{'PassExpires'} eq 'no') {
     # Global policy is non-expiring passwords: do not touch users
     %users = ();
 } elsif($userName) {

--- a/root/etc/e-smith/events/actions/nethserver-directory-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-password-policy
@@ -50,7 +50,7 @@ if($conf{'PassExpires'} eq 'no') {
     %users = ($userName => $PassExpires);
 } else {
     # Change aging attributes where they are already set
-    %users = split(/,/, qx(/usr/libexec/nethserver/list-users -s | jq -j 'to_entries | map(.key + "," + .value.expires) | join(",")'));
+    %users = split(/,/, qx(/usr/libexec/nethserver/list-users -s | /usr/bin/jq -j 'to_entries | map(.key + "," + .value.expires) | join(",")'));
 }
 
 foreach my $ldapAccount (keys %users) {

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_ldap_pp
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/01provider_ldap_pp
@@ -1,0 +1,17 @@
+{
+    #
+    # 01provider_ldap_pp -- do not read password expiration policy
+    # from LDAP shadow attributes, instead ignore them.
+    #
+    if ( ! $sssd_object->isLdap()) {
+        return '';
+    }
+
+    my $pass_expires = $passwordstrength{'PassExpires'} || 'yes';
+
+    if ($sssd_object->isLocalProvider() && $pass_expires eq 'no') {
+        # Local account provider policy depends on PassExpires prop value
+        $provider_config .= "ldap_pwd_policy = none\n";
+    }
+    '';
+}


### PR DESCRIPTION
The current implementation of the password policy model looses information in the following scenario:

1. Global password policy is set to expiring
2. Some users are modified to have non-expiring passwords
3. Policy is changed to non-expiring

By modeling the global parameter in the sssd.conf, we can leave the LDAP attributes untouched and preserve the non-expire flag state across global policy changes.

Note that sssd.conf is not expanded and sssd is not restarted during the package update event. Existing systems are left untouched.

https://github.com/NethServer/dev/issues/6387