### PR TITLE
QA fixes

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-directory-tlspolicy
+++ b/root/etc/e-smith/events/actions/nethserver-directory-tlspolicy
@@ -20,18 +20,16 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-#
-# Following RHEL recommendation https://access.redhat.com/articles/1474813
-#
-
 tlspolicy=$(/sbin/e-smith/config getprop tls policy)
 
 if (( ${tlspolicy:-0} >= 20200510 )); then
+    # Following RHEL recommendation https://access.redhat.com/articles/1474813
+    # Applied "Ciphers - Alternative Values" section + Disabled DH anon: !ADH
     ldapmodify -c -Y EXTERNAL &>/dev/null <<'EOF' || ((errors ++))
 dn: cn=config
 changetype: modify
 replace: olcTLSCipherSuite
-olcTLSCipherSuite: ECDHE-RSA-AES256-SHA384:AES256-SHA256:!RC4:HIGH:!MD5:!aNULL:EDH:!EXP:!SSLV2:!eNULL
+olcTLSCipherSuite: EECDH:EDH:CAMELLIA:ECDH:RSA:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:!3DES:!ADH
 -
 replace: olcTLSProtocolMin
 olcTLSProtocolMin: 3.3

--- a/root/usr/libexec/nethserver/slapd-create-dhparam
+++ b/root/usr/libexec/nethserver/slapd-create-dhparam
@@ -28,7 +28,9 @@ if ! /usr/bin/grep -q 'MIIBCAKCAQEAou6/6s7X2gd+i8+' /etc/openldap/certs/slapd.dh
     exit 0
 fi
 tmpfile=$(mktemp /tmp/slapd-create-dhparam.XXXXXXX)
-trap "/usr/bin/rm -f ${tmpfile}" EXIT
+export RANDFILE=$(mktemp)
+
+trap "/usr/bin/rm -f ${tmpfile} ${RANDFILE}" EXIT
 
 set -e # Exit immediately if any error occurs
 


### PR DESCRIPTION
I repeated the nmap tests with Nmap 7.80 (FC33): PR 57 enabled a weak cipher with TLS policy 20200510. The policy 20180621 is not affected by this regression.

This is the nmap output diff between the stable package and the testing one, pointing at the relevant line:
https://gist.github.com/DavidePrincipi/7cea6aba16d3cef1b940a0ec38dec532/00e6973b1c07eba905a23b0b9e4ba26f8917199b#file-nmap78-nethserver-directory-tlspolicy-20200510-diff-L15

This is the nmap output diff between the stable package and this PR. 
https://gist.github.com/DavidePrincipi/7cea6aba16d3cef1b940a0ec38dec532


Fixed a file access error with openssl RANDFILE
   

Rebase-merge

https://github.com/NethServer/dev/issues/6409